### PR TITLE
Fix AbstractCommand constants to be compatible with Symfony 5.1

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -31,12 +31,12 @@ abstract class AbstractCommand extends Command
     /**
      * @var int Does the command end successfully.
      */
-    protected const SUCCESS = 0;
+    public const SUCCESS = 0;
 
     /**
      * @var int Does the command end with failure.
      */
-    protected const FAILURE = 1;
+    public const FAILURE = 1;
 
     /**
      * @var InputInterface


### PR DESCRIPTION
Theses constants are now defined in Symfony\Component\Console\Command\Command as public
->
https://github.com/symfony/console/blob/5.1/Command/Command.php